### PR TITLE
Remove args not provided by the user in javascript

### DIFF
--- a/src/glacier_ffi.mjs
+++ b/src/glacier_ffi.mjs
@@ -20,7 +20,7 @@ process.on('warning', function (e) {
 });
 
 export const start_args = function () {
-  return Gleam.List.fromArray(process.argv.slice(1));
+  return Gleam.List.fromArray(process.argv.slice(2));
 };
 
 export const cwd = function () {


### PR DESCRIPTION
This change allows running javascript tests with no arguments. As an example, here's the output from running this repo's tests before and after this change.

Before:

```
$ gleam test --target javascript
   Compiled in 0.00s
    Running glacier_test.main

0 tests, 0 failures
```

After:

```
$ gleam test --target javascript

   Compiled in 0.01s
    Running glacier_test.main
..........
10 tests, 0 failures
```
