### PR TITLE
Fixes #16 - bump dependencies, fix string_builder dependency

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -15,7 +15,7 @@ glacier_gleeunit = ">= 1.2.1001 and < 2.0.0"
 # glacier_gleeunit = { path = "../gleeunit" }
 gleam_community_ansi = ">= 1.4.0 and < 2.0.0"
 gleam_community_colour = ">= 1.4.0 and < 2.0.0"
-gleam_stdlib = ">= 0.36.0 and < 2.0.0"
+gleam_stdlib = ">= 0.42.0 and < 2.0.0"
 shellout = ">= 1.6.0 and < 2.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,16 +3,16 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
   { name = "glacier_gleeunit", version = "1.2.1001", build_tools = ["gleam"], requirements = ["argv", "gleam_stdlib"], otp_app = "glacier_gleeunit", source = "hex", outer_checksum = "F63ABBCE21DDBB0410B1365756BA4F897B504EA567A24462A1BC3291972FC981" },
-  { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
-  { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
-  { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
+  { name = "gleam_community_ansi", version = "1.4.2", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "479DEDC748D08B310C9FEB9C4CBEC46B95C874F7F4F2844304D6D20CA78A8BB5" },
+  { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
+  { name = "gleam_json", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "093214EB186A88D301795A94F0A8128C2E24CF1423997ED31A6C6CC67FC3E1A1" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
   { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
-  { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
-  { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
 
 [requirements]
@@ -21,6 +21,6 @@ fs = { version = ">= 8.6.0 and < 9.0.0" }
 glacier_gleeunit = { version = ">= 1.2.1001 and < 2.0.0" }
 gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0" }
 gleam_community_colour = { version = ">= 1.4.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.36.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.42.0 and < 2.0.0" }
 shellout = { version = ">= 1.6.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/glacier.gleam
+++ b/src/glacier.gleam
@@ -1,7 +1,7 @@
 import gleam/io
 import gleam/list
 import gleam/string
-import gleam/string_builder
+import gleam/string_tree
 import gleam_community/ansi
 import gleam_community/colour
 import gleeunit
@@ -221,16 +221,16 @@ fn parse_module_string(
           if char == " " || char == "\t" || char == "\n" || char == "\r\n"
         -> {
           let #(rest_chars, new_import) =
-            parse_import_chars(rest_chars, string_builder.new())
-          let new_import = string_builder.to_string(new_import)
+            parse_import_chars(rest_chars, string_tree.new())
+          let new_import = string_tree.to_string(new_import)
           let updated_imports = [new_import, ..imports]
           parse_module_string(rest_chars, updated_imports, ParseModeSearch, "")
         }
         // Found `import\r` + "\n": Enter Import
         ParseModeSearch, "import\r", "\n" -> {
           let #(rest_chars, new_import) =
-            parse_import_chars(rest_chars, string_builder.new())
-          let imports = [string_builder.to_string(new_import), ..imports]
+            parse_import_chars(rest_chars, string_tree.new())
+          let imports = [string_tree.to_string(new_import), ..imports]
           parse_module_string(rest_chars, imports, ParseModeSearch, "")
         }
         // Found whitespaceish char: Continue Initial with empty collected
@@ -267,7 +267,7 @@ fn parse_module_string(
 ///
 fn parse_import_chars(
   chars: List(String),
-  import_module: string_builder.StringBuilder,
+  import_module: string_tree.StringTree,
 ) {
   // TODO: Try pop grapheme
   case chars {
@@ -287,7 +287,7 @@ fn parse_import_chars(
     -> parse_import_chars(rest_chars, import_module)
     // Append for any other character
     [char, ..rest_chars] ->
-      parse_import_chars(rest_chars, string_builder.append(import_module, char))
+      parse_import_chars(rest_chars, string_tree.append(import_module, char))
   }
 }
 


### PR DESCRIPTION
Most important dependency bump is `gleam_stdlib` to 0.51, with a constraint on >= 0.48.0 (when `string_builder` was removed).

Otherwise all uses of `string_builder` replaced with `string_tree`.

`gleam test` passes 10 test cases - not sure if there is something else I should do to check this?

![image](https://github.com/user-attachments/assets/7f8069ab-4103-4718-a03f-54a81e27ac89)
